### PR TITLE
Checking out of memory

### DIFF
--- a/ADBench/run-all.ps1
+++ b/ADBench/run-all.ps1
@@ -53,8 +53,9 @@ param(# Which build to test.
       # Kill the test after this many seconds 
       [double]$timeout=300,
 
-      # Kill the test if it consumes more than this many gigabytes of RAM
-      [double]$max_memory_amount_in_gb=8,
+      # Kill the test if it consumes more than this many gigabytes of RAM.
+      # If parameter value is less or equal to zero, RAM checking isn't performed.
+      [double]$max_memory_amount_in_gb=-1,
       
       # Where to store the ouput, defaults to tmp/ in the project root 
       [string]$tmpdir="",
@@ -204,7 +205,7 @@ function run_command ($indent, $outfile, $timeout, $cmd) {
 
                 $status = [RunCommandStatus]::Timeout
                 break
-            } elseif ($mem -ge $max_memory_amount_in_bytes) {
+            } elseif (($max_memory_amount_in_gb -gt 0) -and ($mem -ge $max_memory_amount_in_bytes)) {
                 $Process.Kill()
                 $mem = [math]::round($mem / (1024 * 1024 * 1024), 2)
                 Write-Host "${indent}Killed due to consuming $mem GB of operating memory"
@@ -265,7 +266,7 @@ if ($gmm_k_vals_param) { $gmm_k_vals = $gmm_k_vals_param }
 # define test sizes, to be sorted ascending
 sort_size_parameters
 
-# convert max memory amount parameter info to bytes
+# convert max memory amount parameter to bytes
 $max_memory_amount_in_bytes = $max_memory_amount_in_gb * 1024 * 1024 * 1024
 
 # Set tmpdir default

--- a/ADBench/run-all.ps1
+++ b/ADBench/run-all.ps1
@@ -51,7 +51,10 @@ param(# Which build to test.
       [double]$time_limit=10,  
       
       # Kill the test after this many seconds 
-      [double]$timeout=300,    
+      [double]$timeout=300,
+
+      # Kill the test if it consumes more than this many gigabytes of RAM
+      [double]$max_memory_amount=8,
       
       # Where to store the ouput, defaults to tmp/ in the project root 
       [string]$tmpdir="",
@@ -156,11 +159,12 @@ function mkdir_p($path) {
 }
 
 # Type of run command function returning value
-enum RunCommandStatus { Finished; Timeout }
+enum RunCommandStatus { Finished; Timeout; OutOfMemory }
 
 # Run command and (reliably) get output
 function run_command ($indent, $outfile, $timeout, $cmd) {
     write-host "Run [$cmd $args]"
+
     $ProcessInfo = New-Object System.Diagnostics.ProcessStartInfo
     $ProcessInfo.FileName = $cmd
     $ProcessInfo.RedirectStandardError = $true
@@ -169,26 +173,48 @@ function run_command ($indent, $outfile, $timeout, $cmd) {
     $ProcessInfo.Arguments = $args
     $Process = New-Object System.Diagnostics.Process
     $Process.StartInfo = $ProcessInfo
+
     try {
         $Process.Start() | Out-Null
     } catch {
         write-error "Failed to start process $cmd $args"
         throw "failed"
     }
-    $status = $Process.WaitForExit($timeout * 1000)
-    if ($status) {
-        $stdout = $Process.StandardOutput.ReadToEnd().Trim().Replace("`n", "`n${indent}stdout> ")
-        $stderr = $Process.StandardError.ReadToEnd().Trim().Replace("`n", "`n${indent}stderr> ")
-        $allOutput = "${indent}stdout> " + $stdout + "`n${indent}stderr> " + $stderr
-        Write-Host "$allOutput"
-        return [RunCommandStatus]::Finished
-    } else {
-        $Process.Kill()
-        Write-Host "${indent}Killed after $timeout seconds"
-        Store-NonFatalError "Process killed after $timeout seconds`n[$cmd $args]"
-        create_timeout_file $outfile $timeout
-        return [RunCommandStatus]::Timeout
+
+    $OOMCheckingInterval = 500      # milliseconds
+    while (-not $Process.WaitForExit($OOMCheckingInterval)) {
+        $Process.Refresh()
+        if (-not $Process.HasExited) {
+            $mem = 0
+            try {
+                $mem = $Process.PeakPagedMemorySize64
+            } catch {
+                # nothing to do because the process can exit by itself
+            }
+
+            $runTime = ((Get-Date) - $Process.StartTime).Duration().TotalSeconds
+
+            if ($runTime -ge $timeout) {
+                $Process.Kill()
+                Write-Host "${indent}Killed after $timeout seconds"
+                Store-NonFatalError "Process killed after $timeout seconds`n[$cmd $args]"
+                create_timeout_file $outfile $timeout
+                return [RunCommandStatus]::Timeout
+            } elseif ($mem -ge $max_memory_amount_in_bytes) {
+                $Process.Kill()
+                Write-Host "${indent}Killed due to consuming $mem bytes of operating memory"
+                Store-NonFatalError "Process killed due to consuming $mem bytes of operating memory`n[$cmd $args]"
+                return [RunCommandStatus]::OutOfMemory
+            }
+        }
     }
+
+    $stdout = $Process.StandardOutput.ReadToEnd().Trim().Replace("`n", "`n${indent}stdout> ")
+    $stderr = $Process.StandardError.ReadToEnd().Trim().Replace("`n", "`n${indent}stderr> ")
+    $allOutput = "${indent}stdout> " + $stdout + "`n${indent}stderr> " + $stderr
+    Write-Host "$allOutput"
+
+    return [RunCommandStatus]::Finished
 }
 
 # Create result time file with timeout content
@@ -232,6 +258,9 @@ if ($gmm_k_vals_param) { $gmm_k_vals = $gmm_k_vals_param }
 # define test sizes, to be sorted ascending
 sort_size_parameters
 
+# convert max memory amount parameter info to bytes
+$max_memory_amount_in_bytes = $max_memory_amount * 1024 * 1024 * 1024
+
 # Set tmpdir default
 if (!$tmpdir) { $tmpdir = "$dir/tmp" }
 $tmpdir += "/$buildtype"
@@ -261,7 +290,7 @@ enum ToolType
     LSTM = 8
 }
 
-enum RunTestStatus { Success; Timeout; Skipped; IncorrectResults }   # run benchmark statuses
+enum RunTestStatus { Success; Timeout; Skipped; IncorrectResults; OutOfMemory }   # run benchmark statuses
 
 # Custom Tool class
 Class Tool {
@@ -437,6 +466,10 @@ Class Tool {
         if ($run_command_status -eq [RunCommandStatus]::Timeout) {
             $status = [RunTestStatus]::Timeout
         }
+
+        if ($run_command_status -eq [RunCommandStatus]::OutOfMemory) {
+            $status = [RunTestStatus]::OutOfMemory
+        }
         
         return $status
     }
@@ -491,6 +524,16 @@ Class Tool {
         $this.check_correctness($dir_out, $postfix, $fn)
     }
 
+    # Perform actions in case of guaranteed out of memory
+    [void] perform_guaranteed_oom_actions([string]$run_obj, [string]$dir_out, [string]$fn) {
+        Store-NonFatalError "Test didn't run due to guaranteed out of memory`nObjective: $run_obj`nTest file name: $fn"
+
+        # this is made for the result consistency, because in case of out of memory
+        # correctness checking is performed
+        $postfix = $this.get_out_name_postfix($run_obj)
+        $this.check_correctness($dir_out, $postfix, $fn)
+    }
+
     # Run all gmm tests for this tool
     [void] testgmm () {
         if ($this.gmm_both) { $types = @("-FULL", "-SPLIT") }
@@ -507,6 +550,7 @@ Class Tool {
                 mkdir_p $dir_out
 
                 $first_timeout_k = $script:gmm_k_vals[-1] + 1
+                $first_oom_k = $script:gmm_k_vals[-1] + 1
                 foreach ($d in $script:gmm_d_vals) {
                     Write-Host "      d=$d"
                     foreach ($k in $script:gmm_k_vals) {
@@ -518,10 +562,15 @@ Class Tool {
                         if ($k -ge $first_timeout_k) {
                             Write-Host "          Didn't run due to guaranteed timeout"
                             $this.perform_guaranteed_timeout_actions($run_obj, $dir_out, $fn)
+                        } elseif ($k -ge $first_oom_k) {
+                            Write-Host "          Didn't run due to guaranteed out of memory"
+                            $this.perform_guaranteed_oom_actions($run_obj, $dir_out, $fn)
                         } else {
                             $status = $this.run($run_obj, $dir_in, $dir_out, $fn)
                             if ($status -eq [RunTestStatus]::Timeout) {
                                 $first_timeout_k = $k
+                            } elseif ($status -eq [RunTestStatus]::OutOfMemory) {
+                                $first_oom_k = $k
                             }
                         }
                     }
@@ -545,6 +594,9 @@ Class Tool {
             if ($status -eq [RunTestStatus]::Timeout) {
                 Write-Host "      Didn't run due to guaranteed timeout"
                 $this.perform_guaranteed_timeout_actions("BA", $dir_out, $fn)
+            } elseif ($status -eq [RunTestStatus]::OutOfMemory) {
+                Write-Host "      Didn't run due to guaranteed out of memory"
+                $this.perform_guaranteed_oom_actions("BA", $dir_out, $fn)
             } else {
                 $status = $this.run("BA", [Tool]::ba_dir_in, $dir_out, $fn)
             }
@@ -562,6 +614,7 @@ Class Tool {
                 $dir_in = "$([Tool]::hand_dir_in)${type}_$sz/"
                 $dir_out = "$script:tmpdir/hand/${type}_$sz/$($this.name)/"
                 mkdir_p $dir_out
+                $run_obj = "Hand-${type}"
 
                 $status = [RunTestStatus]::Success
                 for ($n = $script:hand_min_n; $n -le $script:hand_max_n; $n++) {
@@ -570,9 +623,12 @@ Class Tool {
 
                     if ($status -eq [RunTestStatus]::Timeout) {
                         Write-Host "        Didn't run due to guaranteed timeout"
-                        $this.perform_guaranteed_timeout_actions("Hand-${type}", $dir_out, $fn)
+                        $this.perform_guaranteed_timeout_actions($run_obj, $dir_out, $fn)
+                    } elseif ($status -eq [RunTestStatus]::OutOfMemory) {
+                        Write-Host "      Didn't run due to guaranteed out of memory"
+                        $this.perform_guaranteed_oom_actions($run_obj, $dir_out, $fn)
                     } else {
-                        $status = $this.run("Hand-${type}", $dir_in, $dir_out, $fn)
+                        $status = $this.run($run_obj, $dir_in, $dir_out, $fn)
                     }
                 }
             }
@@ -585,6 +641,7 @@ Class Tool {
         mkdir_p $dir_out
 
         $first_timeout_c = $script:lstm_c_vals[-1] + 1
+        $first_oom_c = $script:lstm_c_vals[-1] + 1
         foreach ($l in $script:lstm_l_vals) {
             Write-Host "    l=$l"
 
@@ -594,10 +651,15 @@ Class Tool {
                 if ($c -ge $first_timeout_c) {
                     Write-Host "        Didn't run due to guaranteed timeout"
                     $this.perform_guaranteed_timeout_actions("LSTM", $dir_out, "lstm_l${l}_c$c")
+                }elseif ($c -ge $first_oom_c) {
+                    Write-Host "        Didn't run due to guaranteed out of memory"
+                    $this.perform_guaranteed_oom_actions("LSTM", $dir_out, "lstm_l${l}_c$c")
                 } else {
                     $status = $this.run("LSTM", [Tool]::lstm_dir_in, $dir_out, "lstm_l${l}_c$c")
                     if ($status -eq [RunTestStatus]::Timeout) {
                         $first_timeout_c = $c
+                    } elseif ($status -eq [RunTestStatus]::OutOfMemory) {
+                        $first_oom_c = $c
                     }
                 }
             }

--- a/ADBench/run-all.ps1
+++ b/ADBench/run-all.ps1
@@ -206,8 +206,9 @@ function run_command ($indent, $outfile, $timeout, $cmd) {
                 break
             } elseif ($mem -ge $max_memory_amount_in_bytes) {
                 $Process.Kill()
-                Write-Host "${indent}Killed due to consuming $mem bytes of operating memory"
-                Store-NonFatalError "Process killed due to consuming $mem bytes of operating memory`n[$cmd $args]"
+                $mem = [math]::round($mem / (1024 * 1024 * 1024), 2)
+                Write-Host "${indent}Killed due to consuming $mem GB of operating memory"
+                Store-NonFatalError "Process killed due to consuming $mem GB of operating memory`n[$cmd $args]"
                 
                 $status = [RunCommandStatus]::OutOfMemory
                 break

--- a/ADBench/run-all.ps1
+++ b/ADBench/run-all.ps1
@@ -54,8 +54,7 @@ param(# Which build to test.
       [double]$timeout=300,
 
       # Kill the test if it consumes more than this many gigabytes of RAM.
-      # If parameter value is less or equal to zero, RAM checking isn't performed.
-      [double]$max_memory_amount_in_gb=-1,
+      [double]$max_memory_amount_in_gb=[double]::PositiveInfinity,
       
       # Where to store the ouput, defaults to tmp/ in the project root 
       [string]$tmpdir="",
@@ -205,7 +204,7 @@ function run_command ($indent, $outfile, $timeout, $cmd) {
 
                 $status = [RunCommandStatus]::Timeout
                 break
-            } elseif (($max_memory_amount_in_gb -gt 0) -and ($mem -ge $max_memory_amount_in_bytes)) {
+            } elseif ($mem -ge $max_memory_amount_in_bytes) {
                 $Process.Kill()
                 $mem = [math]::round($mem / (1024 * 1024 * 1024), 2)
                 Write-Host "${indent}Killed due to consuming $mem GB of operating memory"

--- a/ADBench/run-all.ps1
+++ b/ADBench/run-all.ps1
@@ -54,7 +54,7 @@ param(# Which build to test.
       [double]$timeout=300,
 
       # Kill the test if it consumes more than this many gigabytes of RAM
-      [double]$max_memory_amount=8,
+      [double]$max_memory_amount_in_gb=8,
       
       # Where to store the ouput, defaults to tmp/ in the project root 
       [string]$tmpdir="",
@@ -259,7 +259,7 @@ if ($gmm_k_vals_param) { $gmm_k_vals = $gmm_k_vals_param }
 sort_size_parameters
 
 # convert max memory amount parameter info to bytes
-$max_memory_amount_in_bytes = $max_memory_amount * 1024 * 1024 * 1024
+$max_memory_amount_in_bytes = $max_memory_amount_in_gb * 1024 * 1024 * 1024
 
 # Set tmpdir default
 if (!$tmpdir) { $tmpdir = "$dir/tmp" }

--- a/docs/GlobalRunner.md
+++ b/docs/GlobalRunner.md
@@ -60,7 +60,7 @@ Parameters:
 
 - `-max_memory_amount_in_gb <Double>`
 
-    Kill the test if it consumes more than this amount of gigabytes of RAM. Parameter value less or equal to zero, then RAM checking isn't performed.
+    Kill the test if it consumes more than this amount of gigabytes of RAM. If parameter value less or equal to zero, then RAM checking isn't performed.
     
 - `-tmpdir <String>`
 

--- a/docs/GlobalRunner.md
+++ b/docs/GlobalRunner.md
@@ -18,7 +18,7 @@ Unless excluded, `run-all.ps1` will run benchmarks on the `Manual` module first 
 
 For every specified _testing module_ `run-all.ps1` will run every specified benchmark that this module supports. So, e.g. if BA benchmarks were requested, but some of the requested modules don't support BA, then BA benchmarks won't be run on these modules and such behavior won't be considered an error.
 
-The script will run benchmarks on _testing modules_ using the corresponding [_benchmark runners_](./Architecture.md#benchmark-runners). It will enforce the hard timeout (default - 5 minutes, overridable in the corresponding argument) and RAM consuming control (default - 8 gigabytes are available for the test, overridable in the corresponding argument) by terminating the runner processes as necessary. It will check that the runner produces a file with timings and a file with the result Jacobian. Then it will compare the result Jacobian to the golden one and output the result of the comparison in JSON format. Unless overridden in the corresponding argument, `run-all.ps1` will delete files with Jacobians it considered correct during comparison.
+The script will run benchmarks on _testing modules_ using the corresponding [_benchmark runners_](./Architecture.md#benchmark-runners). It will enforce the hard timeout (default - 5 minutes, overridable in the corresponding argument) and RAM consuming control (doesn't perform by default, overridable in the corresponding argument) by terminating the runner processes as necessary. It will check that the runner produces a file with timings and a file with the result Jacobian. Then it will compare the result Jacobian to the golden one and output the result of the comparison in JSON format. Unless overridden in the corresponding argument, `run-all.ps1` will delete files with Jacobians it considered correct during comparison.
 
 The script checks guaranteed timeouts. This means that the benchmark for the bigger test will not be run if the run test for the smaller size finishes with timeout. Thus, a GMM objective test will not be run in any case where the `d` and `K` values are both greater than or equal to the `d` and `K` values of a previously timed-out test (of the same count of points). For LSTM such a timeout checking is the same (but for `l` and `c` instead of `d` and `K` respectively). BA and Hand tests with the bigger order number will not be run if any test with the less number is terminated due to timeout. So, for them tests are expected to be sorted respective their sizes. Guaranted out of memory checking, that is also performed by the script, has the same scenario.
 
@@ -60,7 +60,7 @@ Parameters:
 
 - `-max_memory_amount_in_gb <Double>`
 
-    Kill the test if it consumes more than this amount of gigabytes of RAM.
+    Kill the test if it consumes more than this amount of gigabytes of RAM. Parameter value less or equal to zero, then RAM checking isn't performed.
     
 - `-tmpdir <String>`
 

--- a/docs/GlobalRunner.md
+++ b/docs/GlobalRunner.md
@@ -18,18 +18,18 @@ Unless excluded, `run-all.ps1` will run benchmarks on the `Manual` module first 
 
 For every specified _testing module_ `run-all.ps1` will run every specified benchmark that this module supports. So, e.g. if BA benchmarks were requested, but some of the requested modules don't support BA, then BA benchmarks won't be run on these modules and such behavior won't be considered an error.
 
-The script will run benchmarks on _testing modules_ using the corresponding [_benchmark runners_](./Architecture.md#benchmark-runners). It will enforce the hard timeout (default - 5 minutes, overridable in the corresponding argument) by terminating the runner processes as necessary. It will check that the runner produces a file with timings and a file with the result Jacobian. Then it will compare the result Jacobian to the golden one and output the result of the comparison in JSON format. Unless overridden in the corresponding argument, `run-all.ps1` will delete files with Jacobians it considered correct during comparison.
+The script will run benchmarks on _testing modules_ using the corresponding [_benchmark runners_](./Architecture.md#benchmark-runners). It will enforce the hard timeout (default - 5 minutes, overridable in the corresponding argument) and RAM consuming control (default - 8 gigabytes are available for the test, overridable in the corresponding argument) by terminating the runner processes as necessary. It will check that the runner produces a file with timings and a file with the result Jacobian. Then it will compare the result Jacobian to the golden one and output the result of the comparison in JSON format. Unless overridden in the corresponding argument, `run-all.ps1` will delete files with Jacobians it considered correct during comparison.
 
-The script checks guaranteed timeouts. This means that the benchmark for the bigger test will not be run if the run test for the smaller size finishes with timeout. Thus, a GMM objective test will not be run in any case where the `d` and `K` values are both greater than or equal to the `d` and `K` values of a previously timed-out test (of the same count of points). For LSTM such a timeout checking is the same (but for `l` and `c` instead of `d` and `K` respectively). BA and Hand tests with the bigger order number will not be run if any test with the less number is terminated due to timeout. So, for them tests are expected to be sorted respective their sizes.
+The script checks guaranteed timeouts. This means that the benchmark for the bigger test will not be run if the run test for the smaller size finishes with timeout. Thus, a GMM objective test will not be run in any case where the `d` and `K` values are both greater than or equal to the `d` and `K` values of a previously timed-out test (of the same count of points). For LSTM such a timeout checking is the same (but for `l` and `c` instead of `d` and `K` respectively). BA and Hand tests with the bigger order number will not be run if any test with the less number is terminated due to timeout. So, for them tests are expected to be sorted respective their sizes. Guaranted out of memory checking, that is also performed by the script, has the same scenario.
 
-Timeouts, missing output files, and failed comparisons to the golden Jacobians are all considered to be _non-fatal errors_. They cause a warning to be printed when the script finishes and make script's exit code to become non-zero, but don't prevent the execution of other benchmarks.
+Timeouts, out of memory, missing output files, and failed comparisons to the golden Jacobians are all considered to be _non-fatal errors_. They cause a warning to be printed when the script finishes and make script's exit code to become non-zero, but don't prevent the execution of other benchmarks.
 
 ## Usage
 
 Run from PowerShell command prompt. Syntax:
 
 ```powershell
-    ./run-all.ps1 [[-buildtype] <String>] [[-minimum_measurable_time] <Double>] [[-nruns_f] <Int32>] [[-nruns_J] <Int32>] [[-time_limit] <Double>] [[-timeout] <Double>] [[-tmpdir] <String>] [-repeat] [-repeat_failures] [[-tools] <String[]>] [-keep_correct_jacobians] [[-gmm_d_vals_param] <Int32[]>] [[-gmm_k_vals_param] <Int32[]>] [[-gmm_sizes] <String[]>] [[-hand_sizes] <String[]>] [[-ba_min_n] <Int32>] [[-ba_max_n] <Int32>] [[-hand_min_n] <Int32>] [[-hand_max_n] <Int32>] [[-lstm_l_vals] <Int32[]>] [[-lstm_c_vals] <Int32[]>]
+    ./run-all.ps1 [[-buildtype] <String>] [[-minimum_measurable_time] <Double>] [[-nruns_f] <Int32>] [[-nruns_J] <Int32>] [[-time_limit] <Double>] [[-timeout] <Double>] [[-max_memory_amount] <Double>] [[-tmpdir] <String>] [-repeat] [-repeat_failures] [[-tools] <String[]>] [-keep_correct_jacobians] [[-gmm_d_vals_param] <Int32[]>] [[-gmm_k_vals_param] <Int32[]>] [[-gmm_sizes] <String[]>] [[-hand_sizes] <String[]>] [[-ba_min_n] <Int32>] [[-ba_max_n] <Int32>] [[-hand_min_n] <Int32>] [[-hand_max_n] <Int32>] [[-lstm_l_vals] <Int32[]>] [[-lstm_c_vals] <Int32[]>]
 ```    
 
 Parameters:
@@ -57,6 +57,10 @@ Parameters:
 - `-timeout <Double>`
 
     Kill the test after this many seconds.
+
+- `-max_memory_amount <Double>`
+
+    Kill the test if it consumes more than this amount of gigabytes of RAM.
     
 - `-tmpdir <String>`
 

--- a/docs/GlobalRunner.md
+++ b/docs/GlobalRunner.md
@@ -29,7 +29,7 @@ Timeouts, out of memory, missing output files, and failed comparisons to the gol
 Run from PowerShell command prompt. Syntax:
 
 ```powershell
-    ./run-all.ps1 [[-buildtype] <String>] [[-minimum_measurable_time] <Double>] [[-nruns_f] <Int32>] [[-nruns_J] <Int32>] [[-time_limit] <Double>] [[-timeout] <Double>] [[-max_memory_amount] <Double>] [[-tmpdir] <String>] [-repeat] [-repeat_failures] [[-tools] <String[]>] [-keep_correct_jacobians] [[-gmm_d_vals_param] <Int32[]>] [[-gmm_k_vals_param] <Int32[]>] [[-gmm_sizes] <String[]>] [[-hand_sizes] <String[]>] [[-ba_min_n] <Int32>] [[-ba_max_n] <Int32>] [[-hand_min_n] <Int32>] [[-hand_max_n] <Int32>] [[-lstm_l_vals] <Int32[]>] [[-lstm_c_vals] <Int32[]>]
+    ./run-all.ps1 [[-buildtype] <String>] [[-minimum_measurable_time] <Double>] [[-nruns_f] <Int32>] [[-nruns_J] <Int32>] [[-time_limit] <Double>] [[-timeout] <Double>] [[-max_memory_amount_in_gb] <Double>] [[-tmpdir] <String>] [-repeat] [-repeat_failures] [[-tools] <String[]>] [-keep_correct_jacobians] [[-gmm_d_vals_param] <Int32[]>] [[-gmm_k_vals_param] <Int32[]>] [[-gmm_sizes] <String[]>] [[-hand_sizes] <String[]>] [[-ba_min_n] <Int32>] [[-ba_max_n] <Int32>] [[-hand_min_n] <Int32>] [[-hand_max_n] <Int32>] [[-lstm_l_vals] <Int32[]>] [[-lstm_c_vals] <Int32[]>]
 ```    
 
 Parameters:
@@ -58,7 +58,7 @@ Parameters:
 
     Kill the test after this many seconds.
 
-- `-max_memory_amount <Double>`
+- `-max_memory_amount_in_gb <Double>`
 
     Kill the test if it consumes more than this amount of gigabytes of RAM.
     

--- a/docs/GlobalRunner.md
+++ b/docs/GlobalRunner.md
@@ -18,7 +18,7 @@ Unless excluded, `run-all.ps1` will run benchmarks on the `Manual` module first 
 
 For every specified _testing module_ `run-all.ps1` will run every specified benchmark that this module supports. So, e.g. if BA benchmarks were requested, but some of the requested modules don't support BA, then BA benchmarks won't be run on these modules and such behavior won't be considered an error.
 
-The script will run benchmarks on _testing modules_ using the corresponding [_benchmark runners_](./Architecture.md#benchmark-runners). It will enforce the hard timeout (default - 5 minutes, overridable in the corresponding argument) and RAM consuming control (doesn't perform by default, overridable in the corresponding argument) by terminating the runner processes as necessary. It will check that the runner produces a file with timings and a file with the result Jacobian. Then it will compare the result Jacobian to the golden one and output the result of the comparison in JSON format. Unless overridden in the corresponding argument, `run-all.ps1` will delete files with Jacobians it considered correct during comparison.
+The script will run benchmarks on _testing modules_ using the corresponding [_benchmark runners_](./Architecture.md#benchmark-runners). It will enforce the hard timeout (default - 5 minutes, overridable in the corresponding argument) and RAM consuming control (it isn't performed by default, overridable in the corresponding argument) by terminating the runner processes as necessary. It will check that the runner produces a file with timings and a file with the result Jacobian. Then it will compare the result Jacobian to the golden one and output the result of the comparison in JSON format. Unless overridden in the corresponding argument, `run-all.ps1` will delete files with Jacobians it considered correct during comparison.
 
 The script checks guaranteed timeouts. This means that the benchmark for the bigger test will not be run if the run test for the smaller size finishes with timeout. Thus, a GMM objective test will not be run in any case where the `d` and `K` values are both greater than or equal to the `d` and `K` values of a previously timed-out test (of the same count of points). For LSTM such a timeout checking is the same (but for `l` and `c` instead of `d` and `K` respectively). BA and Hand tests with the bigger order number will not be run if any test with the less number is terminated due to timeout. So, for them tests are expected to be sorted respective their sizes. Guaranted out of memory checking, that is also performed by the script, has the same scenario.
 
@@ -60,7 +60,7 @@ Parameters:
 
 - `-max_memory_amount_in_gb <Double>`
 
-    Kill the test if it consumes more than this amount of gigabytes of RAM. If parameter value less or equal to zero, then RAM checking isn't performed.
+    Kill the test if it consumes more than this amount of gigabytes of RAM. This parameter equals to positive infinity by default, so the out of memory checking isn't performed.
     
 - `-tmpdir <String>`
 


### PR DESCRIPTION
The global runner takes additional parameter that defines maximum RAM size that the runner can consume. If test takes more, then it will be killed. Also, guaranteed out of memory checking is performed the same way as guaranteed timeout checking.

This PR solves the issue #172.