### PR TITLE
Rely on environment variables to find Python

### DIFF
--- a/ADBench/CMakeLists.txt
+++ b/ADBench/CMakeLists.txt
@@ -13,6 +13,7 @@ endfunction()
 JOIN("${GMM_D_VALS}" ", " GMM_D_STR)
 JOIN("${GMM_K_VALS}" ", " GMM_K_STR)
 
+set (Python3_FIND_REGISTRY NEVER)
 find_package(Python3 COMPONENTS Interpreter)
 
 if (${Python3_Interpreter_FOUND})

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -1,3 +1,4 @@
+set (Python3_FIND_REGISTRY NEVER)
 find_package(Python3 COMPONENTS Interpreter)
 
 if (${Python3_Interpreter_FOUND})

--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -1,3 +1,4 @@
+set (Python3_FIND_REGISTRY NEVER)
 find_package(Python3 COMPONENTS Interpreter)
 
 if (${Python3_Interpreter_FOUND})

--- a/tools/Autograd/CMakeLists.txt
+++ b/tools/Autograd/CMakeLists.txt
@@ -1,5 +1,6 @@
 project(Autograd)
 
+set (Python3_FIND_REGISTRY NEVER)
 find_package(Python3 COMPONENTS Interpreter)
 
 if (${Python3_Interpreter_FOUND})


### PR DESCRIPTION
When CMake is locating Python on Windows https://cmake.org/cmake/help/latest/module/FindPython3.html it defaults to searching the registry first. This is awkward behaviour on e.g. GitHub Actions where it has a later version of Python available but wouldn't be used if calling e.g. `python -V`.

I think it's closer to expectations to respect the environment variables instead where we want to use a precise version for benchmark comparability. That matches the current documentation which instructs put the binaries on the PATH:

https://github.com/microsoft/ADBench/blob/191c5244e7a815984d302ccbc48372137235a9dd/docs/BuildAndTest.md#prerequisites