### PR TITLE
Get automated builds working again 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,81 @@
+name: ManualAndPyTorchBenchmarks
+
+on: [pull_request]
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/actions/configuring-and-managing-workflows/configuring-a-workflow#configuring-a-build-matrix
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        # Version range or exact version of a Python version to use, using SemVer's version range syntax.
+        python-version: 3.7
+
+    - name: Setup Julia environment
+      # You may pin to the exact commit or the version.
+      # uses: julia-actions/setup-julia@9d7e519ae7e64c071cc7fd8ab44962b5a780063b
+      uses: julia-actions/setup-julia@v1.2.1
+      with:
+        # The Julia version to download (if necessary) and use. Example: 1.0.4
+        version: 1.5
+
+    - name: Setup .NET Core SDK
+      uses: actions/setup-dotnet@v1.6.0
+      with:
+        # SDK version to use. Examples: 2.2.104, 3.1, 3.1.x
+        dotnet-version: 2.1
+    
+    - name: Create Build Environment
+      # Some projects don't allow in-source building, so create a separate build directory
+      # We'll use this as our working directory for all subsequent commands
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      # Note the current convention is to use the -S and -B options here to specify source 
+      # and build directories, but this is only available with CMake 3.13 and higher.  
+      # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      # Execute the build.  You can specify a specific target with "--target <NAME>"
+      run: cmake --build . --config $BUILD_TYPE
+
+# Some tests currently fail!
+
+#     - name: Test
+#       working-directory: ${{runner.workspace}}/build
+#       shell: bash
+#       # Execute tests defined by the CMake configuration.  
+#       # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+#       run: ctest -C $BUILD_TYPE
+
+    - name: Run Benchmark Subset
+      shell: pwsh
+      run: ADBench/run-all.ps1 -timeout 1800 -tools @("Finite", "Manual", "PyTorch") -gmm_d_vals_param @(2,10) -gmm_k_vals_param @(5) -gmm_sizes @("1k") -ba_max_n 1 -hand_max_n 1 -hand_sizes @("small") -lstm_l_vals @(2) -lstm_c_vals @(1024)
+
+    - name: Produce Plots
+      run: python "ADBench/plot_graphs.py" --save
+
+    - name: Upload Plots
+      uses: actions/upload-artifact@v2.1.4
+      with:
+        name: plots
+        path: tmp/graphs/


### PR DESCRIPTION
I've ported https://github.com/microsoft/ADBench/blob/9883bcdf06c27465ce7bd94ad4cff264a62f98ec/adobuilds/pr-win.yml over to GitHub Actions. That lets the build be more integrated rather than potentially calling into an external system (which is also not currently active).

There are a fair number of hard-coded values as before, we might want to look at extracting them to share with scripts but I'm keen to get a CI build active then expand to more of the benchmarks. This currently just does: `("Finite", "Manual", "PyTorch")`.