### PR TITLE
Update the .NET Core module to target .NET Core 3.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/setup-dotnet@v1.6.0
       with:
         # SDK version to use. Examples: 2.2.104, 3.1, 3.1.x
-        dotnet-version: 2.1
+        dotnet-version: 3.1
     
     - name: Create Build Environment
       # Some projects don't allow in-source building, so create a separate build directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,10 +19,10 @@ RUN wget -q https://github.com/PowerShell/PowerShell/releases/download/v6.2.3/po
     && ln -s /utils/powershell/pwsh /usr/local/bin \
     && rm powershell-6.2.3-linux-x64.tar.gz
 
-# Install dotnet 2.1
+# Install dotnet 3.1
 RUN wget -q https://dot.net/v1/dotnet-install.sh \
     && chmod +x dotnet-install.sh \
-    && ./dotnet-install.sh -c 2.1 \
+    && ./dotnet-install.sh -c 3.1 \
     # Create a symlink to dotnet
     && ln -s ~/.dotnet/dotnet /usr/local/bin
 

--- a/docs/BuildAndTest.md
+++ b/docs/BuildAndTest.md
@@ -12,7 +12,7 @@ To run benchmarks in a docker container, follow the guide [here](./Docker.md).
 
 - [CMake 3.12+](https://cmake.org/)
 - A compatible build system and C++ compiler (e.g. MSBuild and MSVC++ on Windows, Make and GCC on Linux)
-- [.NET Core 2.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/2.1)
+- [.NET Core 3.1 SDK](https://dotnet.microsoft.com/download/dotnet-core/3.1)
 - [Python 3](https://www.python.org/)
     
     Pip and setuptools must be installed and upgraded:

--- a/src/dotnet/modules/DiffSharpModule/DiffSharpModule.fsproj
+++ b/src/dotnet/modules/DiffSharpModule/DiffSharpModule.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
  

--- a/src/dotnet/runner/DotnetRunner.csproj
+++ b/src/dotnet/runner/DotnetRunner.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/dotnet/modules/DotnetModulesTests.csproj
+++ b/test/dotnet/modules/DotnetModulesTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/dotnet/runner/DotnetRunnerTests/DotnetRunnerTests.csproj
+++ b/test/dotnet/runner/DotnetRunnerTests/DotnetRunnerTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/dotnet/runner/DotnetRunnerTests/RunnerTests.cs
+++ b/test/dotnet/runner/DotnetRunnerTests/RunnerTests.cs
@@ -46,7 +46,7 @@ namespace DotnetRunnerTests
             Benchmark.MeasureShortestTime(minimumMeasurableTime, runCount, timeLimit, baTest.CalculateObjective);
 
             //Number of runs should be less then runCount variable because totalTime will be reached. 
-            baTestMock.Verify(test => test.CalculateObjective(It.IsAny<int>()), Times.Between(1, (int)Math.Ceiling(timeLimit / executionTime), Range.Exclusive));
+            baTestMock.Verify(test => test.CalculateObjective(It.IsAny<int>()), Times.Between(1, (int)Math.Ceiling(timeLimit / executionTime), Moq.Range.Exclusive));
         }
 
         [Fact]

--- a/test/dotnet/runner/MockTest/MockTest.csproj
+++ b/test/dotnet/runner/MockTest/MockTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <ApplicationIcon />
     <OutputType>Library</OutputType>
     <StartupObject />

--- a/test/dotnet/utils/JacobianComparisonLibTests/JacobianComparisonLibTests.csproj
+++ b/test/dotnet/utils/JacobianComparisonLibTests/JacobianComparisonLibTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In order to update https://diffsharp.github.io/ to 1.0 we need a higher version of .NET Core, I've moved up to the next LTS version, 3.1. I'm putting this change in now as a good incremental step to match other tools.