### PR TITLE
Devops build tidy

### DIFF
--- a/ADBench/azure-devops-ci.ps1
+++ b/ADBench/azure-devops-ci.ps1
@@ -4,8 +4,8 @@
 choco install --limit-output julia
 julia -e 'import Pkg; Pkg.add.([\"SpecialFunctions\", \"ForwardDiff\"])'
 
-python -m pip install --user matplotlib plotly numpy scipy autograd
-python -m pip install torch==1.2.0+cpu torchvision==0.4.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+# python -m pip install --user matplotlib plotly numpy scipy autograd
+# python -m pip install torch==1.2.0+cpu torchvision==0.4.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
 # I'm not sure that setting up vcvars is necessary in Azure Dev Ops.
 # We have a VS2017 host so presumably it has all the paths set up

--- a/ADBench/requirements.txt
+++ b/ADBench/requirements.txt
@@ -1,2 +1,2 @@
-matplotlib>=3.1.1
+matplotlib==3.2.2
 plotly>=4.0.0

--- a/azure-devops.yml
+++ b/azure-devops.yml
@@ -14,6 +14,11 @@ jobs:
       addToPath: true
       architecture: x64
 
+  - task: UseDotNet@2
+    inputs:
+      packageType: 'sdk'
+      version: '3.1.403'
+
   - task: PowerShell@2
     displayName: 'PowerShell Script'
     inputs:


### PR DESCRIPTION
Ensure a matplotlib compatible with plotly
Get a current .NET Core SDK for builds to match .NET projects.
Reduce time spent on dependencies