### PR TITLE
Add missing include in finite.h

### DIFF
--- a/src/cpp/modules/finite/finite.h
+++ b/src/cpp/modules/finite/finite.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <algorithm>
 #include <iostream>
+#include <limits>
 #include <cmath>
 
 const double FINITE_DIFFERENCES_DEFAULT_EPSILON = std::cbrt(std::numeric_limits<double>::epsilon());


### PR DESCRIPTION
On my machine, the C++ code failed to build because of the missing include in this PR. Apparently, `std::numeric_limits` was indirectly included/defined in one of the other header files on older GCC versions; I'm running GCC 11.1.0.